### PR TITLE
Scene graph re-architecture

### DIFF
--- a/examples/aviator.rs
+++ b/examples/aviator.rs
@@ -139,8 +139,7 @@ impl AirPlane {
     }
 
     fn update(&mut self, dt: f32, target: (f32, f32)) {
-        let mut pt = self.propeller_group.transform_mut();
-        pt.rot = pt.rot * three::Orientation::from_angle_x(cgmath::Rad(0.3 * dt));
+        self.propeller_group.transform_mut().rotate(0.3 * dt, 0.0, 0.0);
         self.group.transform_mut().disp =
             cgmath::vec3(0.0 + target.0 * 100.0, 100.0 + target.1 * 75.0, 0.0);
     }
@@ -188,12 +187,8 @@ fn main() {
 
         airplane.update(dt, events.mouse_pos);
 
-        if let (mut t, 0) = (sea.transform_mut(), 0) {
-            t.rot = three::Orientation::from_angle_z(cgmath::Rad(0.005 * dt)) * t.rot;
-        }
-        if let (mut t, 0) = (sky.group.transform_mut(), 0) {
-            t.rot = three::Orientation::from_angle_z(cgmath::Rad(0.01 * dt)) * t.rot;
-        }
+        sea.transform_mut().rotate(0.0, 0.0, 0.005 * dt);
+        sky.group.transform_mut().rotate(0.0, 0.0, 0.01 * dt);
 
         win.render();
     }

--- a/examples/box.rs
+++ b/examples/box.rs
@@ -8,10 +8,10 @@ fn main() {
     cam.position = three::Position::new(0.0, 0.0, 5.0);
     let mut win = three::Window::new("Three-rs box mesh drawing example", cam);
 
-    let geometry = three::Geometry::new_box(1.0, 1.0, 1.0);
+    let geometry = three::Geometry::new_box(3.0, 2.0, 1.0);
     let material = three::Material::MeshBasic { color: 0x00ff00 };
     let mut mesh = win.factory.mesh(geometry, material);
-    mesh.attach(&mut win.scene, None);
+    win.scene.add(&mesh);
 
     let mut angle = cgmath::Rad::zero();
     let speed = 1.5;

--- a/examples/line.rs
+++ b/examples/line.rs
@@ -10,8 +10,8 @@ fn main() {
         three::Position::new(10.0, 0.0, 0.0),
     ]);
     let material = three::Material::LineBasic { color: 0x0000ff };
-    let mut line = win.factory.mesh(geometry, material);
-    line.attach(&mut win.scene, None);
+    let line = win.factory.mesh(geometry, material);
+    win.scene.add(&line);
 
     while let Some(_events) = win.update() {
         win.render();

--- a/examples/sprite.rs
+++ b/examples/sprite.rs
@@ -9,7 +9,7 @@ fn main() {
     };
     let mut sprite = win.factory.sprite(material);
     sprite.transform_mut().scale = 8.0;
-    sprite.attach(&mut win.scene, None);
+    win.scene.add(&sprite);
 
     while let Some(_events) = win.update() {
         win.render();

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -1,7 +1,7 @@
 use std::ops;
 
 use cgmath::prelude::*;
-use cgmath::{self, Transform as Transform_};
+use cgmath;
 
 use {Position, Orientation};
 

--- a/src/factory.rs
+++ b/src/factory.rs
@@ -67,13 +67,15 @@ impl Factory {
 
     pub fn scene(&mut self) -> Scene {
         self.scene_id += 1;
-        let node = self.hub.lock().unwrap().nodes.create(Node {
+        let mut hub = self.hub.lock().unwrap();
+        let node = hub.nodes.create(Node {
             scene: Some(self.scene_id),
             .. Node::new()
         });
         Scene {
             unique_id: self.scene_id,
             node: node,
+            tx: hub.message_tx.clone(),
             hub: self.hub.clone(),
         }
     }

--- a/src/factory.rs
+++ b/src/factory.rs
@@ -69,7 +69,7 @@ impl Factory {
         self.scene_id += 1;
         let mut hub = self.hub.lock().unwrap();
         let node = hub.nodes.create(Node {
-            scene: Some(self.scene_id),
+            scene_id: Some(self.scene_id),
             .. Node::new()
         });
         Scene {

--- a/src/factory.rs
+++ b/src/factory.rs
@@ -12,7 +12,7 @@ use image;
 
 use render::{BackendFactory, BackendResources, GpuData, Vertex};
 use scene::{Group, Mesh, Sprite, Material};
-use {Hub, HubPtr, Node, Normal, Position, Scene, Visual, VisualObject};
+use {Hub, HubPtr, Node, Normal, Position, Scene, Visual};
 
 
 const NORMAL_Z: [I8Norm; 4] = [I8Norm(0), I8Norm(0), I8Norm(1), I8Norm(0)];
@@ -97,26 +97,20 @@ impl Factory {
             let faces: &[u16] = gfx::memory::cast_slice(&geom.faces);
             self.backend.create_vertex_buffer_with_slice(&vertices, faces)
         };
-        Mesh::new(VisualObject {
-            inner: self.hub.lock().unwrap().spawn(),
-            visual: Visual {
-                material: mat,
-                gpu_data: GpuData {
-                    slice: slice,
-                    vertices: vbuf,
-                },
-            }
-        })
+        Mesh::new(self.hub.lock().unwrap().spawn_visual(Visual {
+            material: mat,
+            gpu_data: GpuData {
+                slice: slice,
+                vertices: vbuf,
+            },
+        }))
     }
 
     pub fn sprite(&mut self, mat: Material) -> Sprite {
-        Sprite::new(VisualObject {
-            inner: self.hub.lock().unwrap().spawn(),
-            visual: Visual {
-                material: mat,
-                gpu_data: self.quad.clone(),
-            },
-        })
+        Sprite::new(self.hub.lock().unwrap().spawn_visual(Visual {
+            material: mat,
+            gpu_data: self.quad.clone(),
+        }))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,7 @@ pub type Orientation = cgmath::Quaternion<f32>;
 pub type Transform = cgmath::Decomposed<Normal, Orientation>;
 
 
+#[derive(Clone)]
 struct Visual {
     material: Material,
     gpu_data: GpuData,
@@ -68,6 +69,12 @@ impl Node {
             parent: None,
             scene_id: None,
             visual: None,
+        }
+    }
+    fn new_visual(visual: Visual) -> Self {
+        Node {
+            visual: Some(visual),
+            .. Self::new()
         }
     }
 }
@@ -118,6 +125,18 @@ impl Hub {
         }
     }
 
+    fn spawn_visual(&mut self, visual: Visual) -> VisualObject {
+        VisualObject {
+            inner: Object {
+                visible: true,
+                transform: cgmath::Transform::one(),
+                node: self.nodes.create(Node::new_visual(visual.clone())),
+                tx: self.message_tx.clone(),
+            },
+            visual: visual,
+        }
+    }
+
     fn into_ptr(self) -> HubPtr {
         Arc::new(Mutex::new(self))
     }
@@ -163,7 +182,6 @@ impl Hub {
                 },
                 None => (true, item.scene_id, item.transform),
             };
-
             item.world_visible = visibility;
             item.scene_id = affilation;
             item.world_transform = transform;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@ use render::GpuData;
 pub type Position = cgmath::Point3<f32>;
 pub type Normal = cgmath::Vector3<f32>;
 pub type Orientation = cgmath::Quaternion<f32>;
-pub type Transform = cgmath::Decomposed<Normal, Orientation>;
+pub type Transform = cgmath::Decomposed<cgmath::Vector3<f32>, Orientation>;
 
 
 #[derive(Clone)]

--- a/src/render.rs
+++ b/src/render.rs
@@ -183,13 +183,15 @@ impl Renderer {
         self.encoder.clear_depth(&self.out_depth, 1.0);
 
         let mx_vp = cam.to_view_proj();
-        for visual in &scene.visuals {
+        let mut hub = scene.hub.lock().unwrap();
+        for (visual, transform) in hub.visualize(scene.unique_id) {
+            //TODO: batch per PSO
             let (pso, color, map) = match visual.material {
                 Material::LineBasic { color } => (&self.pso_line_basic, color, None),
                 Material::MeshBasic { color } => (&self.pso_mesh_basic, color, None),
                 Material::Sprite { ref map } => (&self.pso_sprite, !0, Some(map)),
             };
-            let mx_world = cgmath::Matrix4::from(scene.nodes[&visual.node].world);
+            let mx_world = cgmath::Matrix4::from(transform);
             let data = pipe::Data {
                 vbuf: visual.gpu_data.vertices.clone(),
                 mx_vp: mx_vp.into(),

--- a/src/render.rs
+++ b/src/render.rs
@@ -184,6 +184,7 @@ impl Renderer {
 
         let mx_vp = cam.to_view_proj();
         let mut hub = scene.hub.lock().unwrap();
+        hub.process_messages();
         for (visual, transform) in hub.visualize(scene.unique_id) {
             //TODO: batch per PSO
             let (pso, color, map) = match visual.material {

--- a/src/render.rs
+++ b/src/render.rs
@@ -185,14 +185,14 @@ impl Renderer {
         let mx_vp = cam.to_view_proj();
         let mut hub = scene.hub.lock().unwrap();
         hub.process_messages();
-        for (visual, transform) in hub.visualize(scene.unique_id) {
+        hub.visualize(scene.unique_id, |visual, transform| {
             //TODO: batch per PSO
             let (pso, color, map) = match visual.material {
                 Material::LineBasic { color } => (&self.pso_line_basic, color, None),
                 Material::MeshBasic { color } => (&self.pso_mesh_basic, color, None),
                 Material::Sprite { ref map } => (&self.pso_sprite, !0, Some(map)),
             };
-            let mx_world = cgmath::Matrix4::from(transform);
+            let mx_world = cgmath::Matrix4::from(*transform);
             let data = pipe::Data {
                 vbuf: visual.gpu_data.vertices.clone(),
                 mx_vp: mx_vp.into(),
@@ -203,7 +203,7 @@ impl Renderer {
                 out_depth: self.out_depth.clone(),
             };
             self.encoder.draw(&visual.gpu_data.slice, pso, &data);
-        }
+        });
 
         self.encoder.flush(&mut self.device);
         self.window.swap_buffers().unwrap();

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -68,6 +68,16 @@ def_proxy!(TransformProxy<Transform> = SetTransform(node));
 def_proxy!(MaterialProxy<Material> = SetMaterial(visual));
 
 impl Object {
+    pub fn is_visible(&self) -> bool {
+        self.visible
+    }
+
+    pub fn set_visible(&mut self, visible: bool) {
+        self.visible = visible;
+        let msg = Operation::SetVisible(visible);
+        let _ = self.tx.send((self.node.downgrade(), msg));
+    }
+
     pub fn transform(&self) -> &Transform {
         &self.transform
     }

--- a/src/window.rs
+++ b/src/window.rs
@@ -96,7 +96,6 @@ impl<C: Camera> Window<C> {
     }
 
     pub fn render(&mut self) {
-        self.scene.update();
         self.camera.set_aspect(self.renderer.get_aspect());
         self.renderer.render(&self.scene, &self.camera);
     }


### PR DESCRIPTION
This PR makes the engine to keep a single scenegraph with fat nodes, instead of separate little storage-graphics per scene. It's designed to improve ergonomics.

Fixes #6