### PR TITLE
Native projection types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,4 @@ script:
   - cargo build
   - cargo doc
   - cargo test
-  - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then (cargo bench); fi
+# - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then (cargo bench); fi

--- a/examples/aviator/main.rs
+++ b/examples/aviator/main.rs
@@ -25,7 +25,7 @@ fn main() {
     let mut win = three::Window::new("Three-rs Aviator demo", "data/shaders");
     win.scene.background = three::Background::Color(COLOR_BACKGROUND);
 
-    let mut cam = win.factory.perspective_camera(60.0, 0.0, 1.0, 1000.0);
+    let mut cam = win.factory.perspective_camera(60.0, 1.0, 1000.0);
     cam.set_position([0.0, 100.0, 200.0]);
     win.scene.add(&cam);
 
@@ -37,7 +37,7 @@ fn main() {
     let mut dir_light = win.factory.directional_light(0xffffff, 0.9);
     dir_light.look_at([150.0, 350.0, 350.0], [0.0, 0.0, 0.0], None);
     let shadow_map = win.factory.shadow_map(2048, 2048);
-    dir_light.set_shadow(shadow_map, 800.0, 800.0, 1.0, 1000.0);
+    dir_light.set_shadow(shadow_map, 400.0, 1.0, 1000.0);
     win.scene.add(&dir_light);
     let ambient_light = win.factory.ambient_light(0xdc8874, 0.5);
     win.scene.add(&ambient_light);

--- a/examples/lights.rs
+++ b/examples/lights.rs
@@ -2,7 +2,7 @@ extern crate three;
 
 fn main() {
     let mut win = three::Window::new("Three-rs lights example", "data/shaders");
-    let mut cam = win.factory.perspective_camera(45.0, 0.0, 1.0, 50.0);
+    let mut cam = win.factory.perspective_camera(45.0, 1.0, 50.0);
     cam.look_at([-4.0, 15.0, 10.0], [0.0, 0.0, 2.0], None);
 
     let mut hemisphere_light = win.factory.hemisphere_light(0xffffff, 0x8080ff, 0.5);
@@ -14,7 +14,7 @@ fn main() {
     dir_light.look_at([15.0, 35.0, 35.0], [0.0, 0.0, 2.0], None);
     let shadow_map = win.factory.shadow_map(1024, 1024);
     let _debug_shadow = win.renderer.debug_shadow_quad(&shadow_map, 1, [10, 10], [256, 256]);
-    dir_light.set_shadow(shadow_map, 80.0, 80.0, 1.0, 200.0);
+    dir_light.set_shadow(shadow_map, 40.0, 1.0, 200.0);
 
     let mut lights: [&mut three::Object; 4] = [&mut hemisphere_light,
         &mut ambient_light, &mut point_light, &mut dir_light];

--- a/examples/materials.rs
+++ b/examples/materials.rs
@@ -2,7 +2,7 @@ extern crate three;
 
 fn main() {
     let mut win = three::Window::new("Three-rs materials example", "data/shaders");
-    let mut cam = win.factory.perspective_camera(75.0, 0.0, 1.0, 50.0);
+    let mut cam = win.factory.perspective_camera(75.0, 1.0, 50.0);
     cam.set_position([0.0, 0.0, 10.0]);
 
     let mut light = win.factory.point_light(0xffffff, 0.5);

--- a/examples/obj.rs
+++ b/examples/obj.rs
@@ -9,7 +9,7 @@ fn main() {
     let path = args.nth(1).unwrap_or("test_data/car.obj".to_string());
 
     let mut win = three::Window::new("Three-rs obj loading example", "data/shaders");
-    let mut cam = win.factory.perspective_camera(60.0, 0.0, 1.0, 10.0);
+    let mut cam = win.factory.perspective_camera(60.0, 1.0, 10.0);
     cam.look_at([0.0, 2.0, 5.0], [0.0, 0.0, 0.0],
                 Some([0.0, 1.0, 0.0].into()));
 

--- a/examples/shapes.rs
+++ b/examples/shapes.rs
@@ -6,7 +6,7 @@ use cgmath::prelude::*;
 
 fn main() {
     let mut win = three::Window::new("Three-rs shapes example", "data/shaders");
-    let mut cam = win.factory.perspective_camera(75.0, 0.0, 1.0, 50.0);
+    let mut cam = win.factory.perspective_camera(75.0, 1.0, 50.0);
     cam.set_position([0.0, 0.0, 10.0]);
 
     let mut mbox = {

--- a/examples/sprite.rs
+++ b/examples/sprite.rs
@@ -40,7 +40,7 @@ impl Animator {
 
 fn main() {
     let mut win = three::Window::new("Three-rs sprite example", "data/shaders");
-    let cam = win.factory.orthographic_camera(-10.0, 10.0, 10.0, -10.0, -10.0, 10.0);
+    let cam = win.factory.orthographic_camera([0.0, 0.0], 10.0, -10.0, 10.0);
 
     let material = three::Material::Sprite {
         map: win.factory.load_texture("test_data/pikachu_anim.png"),

--- a/src/factory.rs
+++ b/src/factory.rs
@@ -4,7 +4,7 @@ use std::io::BufReader;
 use std::fs::File;
 use std::path::Path;
 
-use cgmath::{self, Transform as Transform_};
+use cgmath::Transform as Transform_;
 use genmesh::{Polygon, EmitTriangles, Triangulate, Vertex as GenVertex};
 use genmesh::generators::{self, IndexedPolygon, SharedVertex};
 use gfx;
@@ -15,12 +15,12 @@ use image;
 use mint;
 use obj;
 
+use camera::{Orthographic, Perspective};
 use render::{BackendFactory, BackendResources, GpuData, Vertex, ShadowFormat};
 use scene::{Color, Background, Group, Mesh, Sprite, Material,
             AmbientLight, DirectionalLight, HemisphereLight, PointLight};
 use {Hub, HubPtr, SubLight, Node, SubNode,
-     LightData, Object, Scene,
-     Camera, OrthographicCamera, PerspectiveCamera};
+     LightData, Object, Scene, Camera};
 
 
 const NORMAL_Z: [I8Norm; 4] = [I8Norm(0), I8Norm(0), I8Norm(1), I8Norm(0)];
@@ -148,25 +148,28 @@ impl Factory {
 
     /// Create new [Orthographic](https://en.wikipedia.org/wiki/Orthographic_projection) Camera.
     /// It's used basically to render 2D.
-    pub fn orthographic_camera(&mut self, left: f32, right: f32, top: f32, bottom: f32,
-                               near: f32, far: f32) -> OrthographicCamera {
+    pub fn orthographic_camera<P>(&mut self, center: P,
+                               extent_y: f32, near: f32, far: f32)
+                               -> Camera<Orthographic>
+    where P: Into<mint::Point2<f32>>
+    {
         Camera {
             object: self.hub.lock().unwrap().spawn_empty(),
-            projection: cgmath::Ortho{ left, right, bottom, top, near, far },
+            projection: Orthographic {
+                center: center.into(),
+                extent_y, near, far,
+            },
         }
     }
 
     /// Create new [Perspective](https://en.wikipedia.org/wiki/Perspective_(graphical)) Camera.
     /// It's used basically to render 3D.
-    pub fn perspective_camera(&mut self, fov: f32, aspect: f32,
-                              near: f32, far: f32) -> PerspectiveCamera {
+    pub fn perspective_camera(&mut self, fov_y: f32, near: f32, far: f32)
+                              -> Camera<Perspective> {
         Camera {
             object: self.hub.lock().unwrap().spawn_empty(),
-            projection: cgmath::PerspectiveFov {
-                fovy: cgmath::Deg(fov).into(),
-                aspect: aspect,
-                near: near,
-                far: far,
+            projection: Perspective {
+                fov_y, near, far,
             },
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@ mod scene;
 #[cfg(feature = "opengl")]
 mod window;
 
+pub use camera::{Orthographic, Perspective};
 pub use factory::{Factory, Geometry, ShadowMap, Texture};
 pub use input::{Button, KeyAxis, Timer, Input,
                 KEY_ESCAPE, KEY_SPACE, AXIS_LEFT_RIGHT, AXIS_DOWN_UP};
@@ -58,7 +59,7 @@ enum SubLight {
 
 #[derive(Clone, Debug)]
 enum ShadowProjection {
-    Ortho(cgmath::Ortho<f32>),
+    Ortho(Orthographic),
 }
 
 #[derive(Clone, Debug)]
@@ -104,25 +105,13 @@ pub struct Object {
     tx: mpsc::Sender<Message>,
 }
 
-/// Camera is used to render Scene with specific Projection.
-/// See [`OrthographicCamera`](type.OrthographicCamera.html),
-/// [`PerspectiveCamera`](type.PerspectiveCamera.html).
+/// Camera is used to render Scene with specific `Projection`.
 pub struct Camera<P> {
     object: Object,
-    projection: P,
+    /// Projection parameters of this camera.
+    pub projection: P,
 }
 
-// warning: public exposure of `cgmath` here
-/// See [`Orthographic projection`](https://en.wikipedia.org/wiki/3D_projection#Orthographic_projection).
-pub type OrthographicCamera = Camera<cgmath::Ortho<f32>>;
-/// See [`Perspective projection`](https://en.wikipedia.org/wiki/3D_projection#Perspective_projection).
-pub type PerspectiveCamera = Camera<cgmath::PerspectiveFov<f32>>;
-
-/// Generic trait for different graphics projections.
-pub trait Projection {
-    /// Represents projection as projection matrix.
-    fn get_matrix(&self, aspect: f32) -> mint::ColumnMatrix4<f32>;
-}
 
 type Message = (froggy::WeakPointer<Node>, Operation);
 enum Operation {

--- a/src/render.rs
+++ b/src/render.rs
@@ -12,9 +12,10 @@ use mint;
 
 pub use self::back::Factory as BackendFactory;
 pub use self::back::Resources as BackendResources;
+use camera::Projection;
 use factory::{Factory, ShadowMap, Texture};
 use scene::{Color, Background, Material};
-use {SubLight, SubNode, Scene, ShadowProjection, Camera, Projection};
+use {SubLight, SubNode, Scene, ShadowProjection, Camera};
 
 /// The format of the back buffer color requested from the windowing system.
 pub type ColorFormat = gfx::format::Srgba8;

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -1,11 +1,11 @@
 use std::ops;
 
-use cgmath::Ortho;
 use froggy::Pointer;
 use mint;
 
 use {Object, Operation, Node, SubNode,
      Scene, ShadowProjection, Transform};
+use camera::Orthographic;
 use factory::{Geometry, ShadowMap, Texture};
 
 /// Color represented by 4-bytes hex number.
@@ -19,25 +19,21 @@ pub enum Background {
     //TODO: texture, cubemap
 }
 
-/// Material is the enhancement of Texture that is used to setup appearence of [`Mesh`](struct.Mesh.html).
+/// Material is the enhancement of Texture that is used to setup appearance of [`Mesh`](struct.Mesh.html).
+#[allow(missing_docs)]
 #[derive(Clone, Debug)]
 pub enum Material {
     /// Basic wireframe with specific `Color`.
-    #[allow(missing_docs)]
     LineBasic { color: Color },
     /// Basic material with color, optional `Texture` and optional wireframe mode.
-    #[allow(missing_docs)]
     MeshBasic { color: Color, map: Option<Texture<[f32; 4]>>, wireframe: bool },
     /// Lambertian diffuse reflection. This technique causes all closed polygons
     /// (such as a triangle within a 3D mesh) to reflect light equally in all
     /// directions when rendered.
-    #[allow(missing_docs)]
     MeshLambert { color: Color, flat: bool },
     /// Material that uses Phong reflection model.
-    #[allow(missing_docs)]
     MeshPhong { color: Color, glossiness: f32 },
     /// 2D Sprite.
-    #[allow(missing_docs)]
     Sprite { map: Texture<[f32; 4]> },
 }
 
@@ -270,12 +266,10 @@ impl DirectionalLight {
 
     /// Adds shadow map for this light source.
     pub fn set_shadow(&mut self, map: ShadowMap,
-                      width: f32, height: f32, near: f32, far: f32) {
-        let sp = ShadowProjection::Ortho(Ortho {
-            left: -0.5 * width,
-            right: 0.5 * width,
-            bottom: -0.5 * height,
-            top: 0.5 * height,
+                      extent_y: f32, near: f32, far: f32) {
+        let sp = ShadowProjection::Ortho(Orthographic {
+            center: [0.0; 2].into(),
+            extent_y,
             near,
             far,
         });

--- a/src/window.rs
+++ b/src/window.rs
@@ -1,6 +1,7 @@
 use glutin;
 
-use {Camera, Projection, Scene};
+use {Camera, Scene};
+use camera::Projection;
 use input::Input;
 use render::Renderer;
 use factory::Factory;


### PR DESCRIPTION
Finishes the last bits of #4
Also simplifies the projection setups.

Basically, we only provide the vertical FOV/extent, and the horizontal is derived from the current aspect ratio in order to produce square pixels.