### PR TITLE
Added macro for implementing conversion traits on structs that wrap three-rs types.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,8 @@ extern crate gfx_window_glutin;
 #[cfg(feature = "opengl")]
 extern crate glutin;
 
+#[macro_use]
+mod macros;
 mod camera;
 mod factory;
 mod input;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -8,18 +8,18 @@
 /// * `Deref<Target=Object>`
 /// * `DerefMut<Object>`
 ///
-/// ```
+/// ```rust,ignore
 /// // Implements conversion traits for MyStruct using field `internal_three_type`
-/// three_object_wrapper!(MyStruct#internal_three_type);
+/// three_object_wrapper!(MyStruct::internal_three_type);
 /// // If field is omitted, it defaults to `object`
-/// three_object_wrapper!(MyStruct); // equivalent to three_object_wrapper!(MyStruct#object);
+/// three_object_wrapper!(MyStruct); // equivalent to three_object_wrapper!(MyStruct::object);
 /// ```
 #[macro_export]
 macro_rules! three_object_wrapper {
     ($($name:ident),*) => {
-        three_object_wrapper!($($name#object),*);
+        three_object_wrapper!($($name::object),*);
     };
-    ($($name:ident # $field:ident),*) => {
+    ($($name:ident::$field:ident),*) => {
         $(
             impl AsRef<$crate::NodePointer> for $name {
                 fn as_ref(&self) -> &$crate::NodePointer {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,44 @@
+/// Implements conversion traits on a type wrapping a three-rs type. Useful for when you wrap a
+/// three-rs type with your own struct. Allows you to use that struct in place of any three-rs
+/// object.
+///
+/// Implements the following traits:
+///
+/// * `AsRef<NodePointer>`
+/// * `Deref<Target=Object>`
+/// * `DerefMut<Object>`
+///
+/// ```
+/// // Implements conversion traits for MyStruct using field `internal_three_type`
+/// three_object_wrapper!(MyStruct#internal_three_type);
+/// // If field is omitted, it defaults to `object`
+/// three_object_wrapper!(MyStruct); // equivalent to three_object_wrapper!(MyStruct#object);
+/// ```
+#[macro_export]
+macro_rules! three_object_wrapper {
+    ($($name:ident),*) => {
+        three_object_wrapper!($($name#object),*);
+    };
+    ($($name:ident # $field:ident),*) => {
+        $(
+            impl AsRef<$crate::NodePointer> for $name {
+                fn as_ref(&self) -> &$crate::NodePointer {
+                    self.$field.as_ref()
+                }
+            }
+
+            impl ::std::ops::Deref for $name {
+                type Target = Object;
+                fn deref(&self) -> &Object {
+                    &self.$field
+                }
+            }
+
+            impl ::std::ops::DerefMut for $name {
+                fn deref_mut(&mut self) -> &mut Object {
+                    &mut self.$field
+                }
+            }
+        )*
+    };
+}


### PR DESCRIPTION
This macro makes it really easy for structs that simply wrap a three-rs type to implement the right traits so that those custom types can interop with three-rs methods really easily.

The macro is nice and flexible and the field name is optional. I chose the syntax `MyStruct#field` because it seemed more natural to me than `MyStruct.field` or `MyStruct::field` (since `x::y` is usually for modules or methods, not fields).

[See the effect of this change here](https://github.com/sunjay/panda/commit/d508806d9f5f47fe4267b98f5823142108decaac)

Really wanted to replace macros in `src/scene.rs` with some macros that could be used outside of the crate, but unfortunately that didn't workout because while internal three objects have access to the `node` field, structs external to the crate do not. This causes problems in `as_ref` and if that one was going to deviate, we might as well make a single macro for the special purpose of classes that wrap three-rs objects.