### PR TITLE
Added zoom to orbit camera

### DIFF
--- a/src/camera.rs
+++ b/src/camera.rs
@@ -156,12 +156,14 @@ impl OrbitControls {
     }
 
     pub fn update(&mut self, input: &Input) {
-        if !self.button.is_hit(input) {
+        if !self.button.is_hit(input) && !(input.get_mouse_wheel_movements().len()!=0) {
             self.mouse_base = None;
             return
         }
 
         let cur = input.get_mouse_pos();
+        if self.mouse_base == None { self.mouse_base = Some(cur); } // Fake previous mouse input
+                                                                    // if change only comes from mouse wheel
         if let Some(base) = self.mouse_base {
             let pre = Decomposed {
                 disp: -self.target.to_vec(),
@@ -171,7 +173,7 @@ impl OrbitControls {
             let axis = self.transform.rot * Vector3::unit_x();
             let q_hor = Quaternion::from_axis_angle(axis, Rad(self.speed * (cur.y - base.y)));
             let post = Decomposed {
-                scale: 1.0,
+                scale: 1.0 + input.get_mouse_wheel_movements().iter().sum::<f32>()/1000.0,
                 rot: q_hor * q_ver,
                 disp: self.target.to_vec(),
             };


### PR DESCRIPTION
As above, some small changes in the OrbitControls code to add a zoom function to the camera using the mouse wheel:

In the update function, I added a check to input.get_mouse_wheel_movements, then implemented some code to fake the old mouse position as the new one (ie no movement) if the only update was to mouse wheel, then changed scale to 1 + (sum of mouse wheel movements)/1000

It works nicely on the obj example. I'm sure it could be more elegant, but in the meantime, it works...