### PR TITLE
Make it possible to run examples from anywhere in the source tree

### DIFF
--- a/examples/anim.rs
+++ b/examples/anim.rs
@@ -93,7 +93,9 @@ fn make_geometry() -> three::Geometry {
 }
 
 fn main() {
-    let mut win = three::Window::new("Three-rs mesh blending example", "data/shaders").build();
+    let shaders_path: String = format!("{}/data/shaders", env!("CARGO_MANIFEST_DIR"));
+    let shaders_path_str: &str = shaders_path.as_str();
+    let mut win = three::Window::new("Three-rs mesh blending example", shaders_path_str).build();
     let mut cam = win.factory.perspective_camera(60.0, 1.0, 1000.0);
     cam.look_at([100.0, 0.0, 100.0], [0.0, 0.0, 30.0], Some([0.0, 1.0, 0.0].into()));
 

--- a/examples/aviator/main.rs
+++ b/examples/aviator/main.rs
@@ -22,7 +22,9 @@ fn main() {
     env_logger::init().unwrap();
     let mut rng = rand::thread_rng();
 
-    let mut win = three::Window::new("Three-rs Aviator demo", "data/shaders").build();
+    let shaders_path: String = format!("{}/data/shaders", env!("CARGO_MANIFEST_DIR"));
+    let shaders_path_str: &str = shaders_path.as_str();
+    let mut win = three::Window::new("Three-rs Aviator demo", shaders_path_str).build();
     win.scene.background = three::Background::Color(COLOR_BACKGROUND);
 
     let mut cam = win.factory.perspective_camera(60.0, 1.0, 1000.0);

--- a/examples/group.rs
+++ b/examples/group.rs
@@ -111,7 +111,9 @@ const SPEEDS: [f32; 5] = [
 ];
 
 fn main() {
-    let mut win = three::Window::new("Three-rs group example", "data/shaders").build();
+    let shaders_path: String = format!("{}/data/shaders", env!("CARGO_MANIFEST_DIR"));
+    let shaders_path_str: &str = shaders_path.as_str();
+    let mut win = three::Window::new("Three-rs group example", shaders_path_str).build();
     win.scene.background = three::Background::Color(0x204060);
 
     let mut cam = win.factory.perspective_camera(60.0, 1.0, 100.0);

--- a/examples/lights.rs
+++ b/examples/lights.rs
@@ -1,7 +1,9 @@
 extern crate three;
 
 fn main() {
-    let mut win = three::Window::new("Three-rs lights example", "data/shaders").build();
+    let shaders_path: String = format!("{}/data/shaders", env!("CARGO_MANIFEST_DIR"));
+    let shaders_path_str: &str = shaders_path.as_str();
+    let mut win = three::Window::new("Three-rs lights example", shaders_path_str).build();
     let mut cam = win.factory.perspective_camera(45.0, 1.0, 50.0);
     cam.look_at([-4.0, 15.0, 10.0], [0.0, 0.0, 2.0], None);
 

--- a/examples/materials.rs
+++ b/examples/materials.rs
@@ -1,7 +1,9 @@
 extern crate three;
 
 fn main() {
-    let mut win = three::Window::new("Three-rs materials example", "data/shaders").build();
+    let shaders_path: String = format!("{}/data/shaders", env!("CARGO_MANIFEST_DIR"));
+    let shaders_path_str: &str = shaders_path.as_str();
+    let mut win = three::Window::new("Three-rs materials example", shaders_path_str).build();
     let mut cam = win.factory.perspective_camera(75.0, 1.0, 50.0);
     cam.set_position([0.0, 0.0, 10.0]);
 

--- a/examples/obj.rs
+++ b/examples/obj.rs
@@ -4,9 +4,12 @@ use std::env;
 
 fn main() {
     let mut args = env::args();
-    let path = args.nth(1).unwrap_or("test_data/car.obj".to_string());
+    let obj_path: String = format!("{}/test_data/car.obj", env!("CARGO_MANIFEST_DIR"));
+    let path = args.nth(1).unwrap_or(obj_path);
 
-    let mut win = three::Window::new("Three-rs obj loading example", "data/shaders").build();
+    let shaders_path: String = format!("{}/data/shaders", env!("CARGO_MANIFEST_DIR"));
+    let shaders_path_str: &str = shaders_path.as_str();
+    let mut win = three::Window::new("Three-rs obj loading example", shaders_path_str).build();
     let cam = win.factory.perspective_camera(60.0, 1.0, 10.0);
     let mut controls = three::OrbitControls::new(&cam, [0.0, 2.0, -5.0], [0.0, 0.0, 0.0]).build();
 

--- a/examples/pbr.rs
+++ b/examples/pbr.rs
@@ -118,7 +118,9 @@ fn import(path_str: &str, factory: &mut three::Factory) -> three::Mesh {
 }
 
 fn main() {
-    let mut win = three::Window::new("Three-rs PBR example", "data/shaders").build();
+    let shaders_path: String = format!("{}/data/shaders", env!("CARGO_MANIFEST_DIR"));
+    let shaders_path_str: &str = shaders_path.as_str();
+    let mut win = three::Window::new("Three-rs PBR example", shaders_path_str).build();
     let mut cam = win.factory.perspective_camera(75.0, 0.01, 100.0);
     let mut yaw: f32 = 0.8;
     let mut distance: f32 = 3.9;
@@ -129,7 +131,8 @@ fn main() {
     win.scene.add(&light);
     win.scene.background = three::Background::Color(0xC6F0FF);
 
-    let path = std::env::args().nth(1).unwrap_or("test_data/SciFiHelmet.gltf".into());
+    let helmet_gltf_path = format!("{}/test_data/SciFiHelmet.gltf", env!("CARGO_MANIFEST_DIR"));
+    let path = std::env::args().nth(1).unwrap_or(helmet_gltf_path);
     let mesh = import(&path, &mut win.factory);
     win.scene.add(&mesh);
 

--- a/examples/shapes.rs
+++ b/examples/shapes.rs
@@ -5,7 +5,9 @@ extern crate three;
 use cgmath::prelude::*;
 
 fn main() {
-    let mut win = three::Window::new("Three-rs shapes example", "data/shaders").build();
+    let shaders_path: String = format!("{}/data/shaders", env!("CARGO_MANIFEST_DIR"));
+    let shaders_path_str: &str = shaders_path.as_str();
+    let mut win = three::Window::new("Three-rs shapes example", shaders_path_str).build();
     let mut cam = win.factory.perspective_camera(75.0, 1.0, 50.0);
     cam.set_position([0.0, 0.0, 10.0]);
 

--- a/examples/sprite.rs
+++ b/examples/sprite.rs
@@ -39,11 +39,15 @@ impl Animator {
 }
 
 fn main() {
-    let mut win = three::Window::new("Three-rs sprite example", "data/shaders").build();
+    let shaders_path: String = format!("{}/data/shaders", env!("CARGO_MANIFEST_DIR"));
+    let shaders_path_str: &str = shaders_path.as_str();
+    let mut win = three::Window::new("Three-rs sprite example", shaders_path_str).build();
     let cam = win.factory.orthographic_camera([0.0, 0.0], 10.0, -10.0, 10.0);
 
+    let pikachu_path: String = format!("{}/test_data/pikachu_anim.png", env!("CARGO_MANIFEST_DIR"));
+    let pikachu_path_str: &str = pikachu_path.as_str();
     let material = three::Material::Sprite {
-        map: win.factory.load_texture("test_data/pikachu_anim.png"),
+        map: win.factory.load_texture(pikachu_path_str),
     };
     let mut sprite = win.factory.sprite(material);
     sprite.set_scale(8.0);


### PR DESCRIPTION
Now you can call "cargo run --example <example name>" from any directory,
not only from the root "Cargo.toml" directory.