### PR TITLE
Make paths in mtl files relative

### DIFF
--- a/test_data/texture.mtl
+++ b/test_data/texture.mtl
@@ -10,4 +10,4 @@ Ke 0.000000 0.000000 0.000000
 Ni 1.000000
 d 1.000000
 illum 2
-map_Kd test_data/texture.png
+map_Kd texture.png


### PR DESCRIPTION
When loading textures referenced in a MTL file, load them relative to the location of the MTL file, not the current working directory.