### PR TITLE
Update winit to 0.7.5 to fix compilation on Mac (nightly)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ itertools = "0.6"
 log = "0.3"
 obj = { version = "0.6", features = ["genmesh"] }
 mint = "0.4.2"
-winit = "0.6"
+winit = "0.7.5"
 # OpenGL
 gfx_device_gl = { version = "0.14", optional = true }
 gfx_window_glutin = { version = "0.17", optional = true }


### PR DESCRIPTION
`winit 0.6.4` depends on the slightly outdated `cocoa 0.5.2`, which can't be compiled with nightly on Mac (56 x ```error[E0277]: the trait bound `Self: std::marker::Sized` is not satisfied```).