### PR TITLE
Allow mesh instances to duplicate their materials

### DIFF
--- a/examples/aviator/sky.rs
+++ b/examples/aviator/sky.rs
@@ -23,7 +23,7 @@ impl Cloud {
         let material = three::Material::MeshLambert{ color: COLOR_WHITE, flat: true };
         let template = factory.mesh(geo, material.clone());
         for i in 0 .. rng.gen_range(3, 6) {
-            let mut m = factory.mesh_instance(&template, material.clone());
+            let mut m = factory.mesh_instance(&template, None);
             let rot: cgmath::Quaternion<f32> = rng.gen();
             let q = rot.normalize();
             m.set_transform([i as f32 * 15.0, rng.next_f32() * 10.0, rng.next_f32() * 10.0],

--- a/examples/group.rs
+++ b/examples/group.rs
@@ -72,7 +72,7 @@ fn create_cubes(factory: &mut three::Factory,
             let mat = materials[next.mat_id].clone();
             let mut cube = Cube {
                 group: factory.group(),
-                mesh: factory.mesh_instance(&list[0].mesh, mat),
+                mesh: factory.mesh_instance(&list[0].mesh, Some(mat)),
                 level_id: next.lev_id,
                 orientation: child.rot,
             };

--- a/src/factory.rs
+++ b/src/factory.rs
@@ -299,7 +299,13 @@ impl Factory {
 
     /// Create a `Mesh` sharing the geometry with another one.
     /// Rendering a sequence of meshes with the same geometry is faster.
-    pub fn mesh_instance(&mut self, template: &Mesh, mat: Material) -> Mesh {
+    ///
+    /// When `new_mat` is `None`, the material is duplicated from its template.
+    pub fn mesh_instance(
+        &mut self,
+        template: &Mesh,
+        new_mat: Option<Material>,
+    ) -> Mesh {
         let mut hub = self.hub.lock().unwrap();
         let gpu_data = match hub.nodes[&template.node].sub_node {
             SubNode::Visual(_, ref gpu) => GpuData {
@@ -308,6 +314,12 @@ impl Factory {
             },
             _ => unreachable!()
         };
+        let mat = new_mat.unwrap_or_else(|| {
+            match hub.nodes[&template.node].sub_node {
+                SubNode::Visual(ref mat, _) => mat.clone(),
+                _ => unreachable!()
+            }
+        });
         Mesh {
             object: hub.spawn_visual(mat, gpu_data),
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -254,7 +254,7 @@ pub struct Scene {
 ///
 /// Creating a red triangle.
 ///
-/// ```rust
+/// ```rust,no_run
 /// # let shaders_path = format!("{}/data/shaders", env!("CARGO_MANIFEST_DIR"));
 /// # let mut win = three::Window::new("Example", &shaders_path).build();
 /// # let factory = &mut win.factory;
@@ -275,7 +275,7 @@ pub struct Scene {
 ///
 /// Duplicating a mesh.
 ///
-/// ```rust
+/// ```rust,no_run
 /// # let shaders_path = format!("{}/data/shaders", env!("CARGO_MANIFEST_DIR"));
 /// # let mut win = three::Window::new("Example", &shaders_path).build();
 /// # let factory = &mut win.factory;
@@ -296,7 +296,7 @@ pub struct Scene {
 ///    wireframe: false,
 ///    map: None,
 /// };
-/// let mut duplicate = factory.mesh_instance(&mesh, yellow_material);
+/// let mut duplicate = factory.mesh_instance(&mesh, Some(yellow_material));
 /// // Duplicated meshes share their geometry but can be transformed individually
 /// // and be rendered with different materials.
 /// duplicate.set_position([1.2, 3.4, 5.6]);


### PR DESCRIPTION
There might be a more idiomatic way of providing this functionality. Would it be better to provide a `Mesh::material()` function instead?